### PR TITLE
Dispose remote renderer in deactivate call

### DIFF
--- a/lib/src/call_sample/call_sample.dart
+++ b/lib/src/call_sample/call_sample.dart
@@ -45,7 +45,7 @@ class _CallSampleState extends State<CallSample> {
     super.deactivate();
     if (_signaling != null) _signaling.close();
     _localRenderer.dispose();
-    _localRenderer.dispose();
+    _remoteRenderer.dispose();
   }
 
   void _connect() async {


### PR DESCRIPTION
Seems like this was a copy-n-paste error, the local renderer was previously disposed of twice ☺️ 