### PR TITLE
fix(signaling): save reference to peer connection before removing it

### DIFF
--- a/lib/src/call_sample/signaling.dart
+++ b/lib/src/call_sample/signaling.dart
@@ -201,7 +201,7 @@ class Signaling {
       case 'leave':
         {
           var id = data;
-          _peerConnections.remove(id);
+          var pc = _peerConnections.remove(id);
           _dataChannels.remove(id);
 
           if (_localStream != null) {
@@ -209,10 +209,8 @@ class Signaling {
             _localStream = null;
           }
 
-          var pc = _peerConnections[id];
           if (pc != null) {
             pc.close();
-            _peerConnections.remove(id);
           }
           this._sessionId = null;
           if (this.onStateChange != null) {


### PR DESCRIPTION
Before, the peer connection would always be null when we null check it. Now we save a reference to it when it is removed so we can properly call `pc.close()`