### PR TITLE
Convert onIceCandidate to async and introduce a delay

### DIFF
--- a/lib/src/call_sample/signaling.dart
+++ b/lib/src/call_sample/signaling.dart
@@ -392,21 +392,27 @@ class Signaling {
         sender.setParameters(parameters);
       */
     }
-    pc.onIceCandidate = (candidate) {
+    pc.onIceCandidate = (candidate) async {
       if (candidate == null) {
         print('onIceCandidate: complete!');
         return;
       }
-      _send('candidate', {
-        'to': peerId,
-        'from': _selfId,
-        'candidate': {
-          'sdpMLineIndex': candidate.sdpMlineIndex,
-          'sdpMid': candidate.sdpMid,
-          'candidate': candidate.candidate,
-        },
-        'session_id': sessionId,
-      });
+      // This delay is needed to allow enough time to try an ICE candidate
+      // before skipping to the next one. 1 second is just an heuristic value
+      // and should be thoroughly tested in your own environment.
+      await Future.delayed(
+          const Duration(seconds: 1),
+          () => _send('candidate', {
+            'to': peerId,
+            'from': _selfId,
+            'candidate': {
+              'sdpMLineIndex': candidate.sdpMlineIndex,
+              'sdpMid': candidate.sdpMid,
+              'candidate': candidate.candidate,
+            },
+            'session_id': sessionId,
+          })
+      );
     };
 
     pc.onIceConnectionState = (state) {};


### PR DESCRIPTION
This PR introduces a delay (to be web compliant it cannot be done with dart:io but we have to relay to an async declaration) to allow ICE candidates to be processed by the client.
Without this, I often found myself unable to establish a connection (especially in relay, with the network lag that implicitly happens), because the client just "skipped over" to the next candidate almost immediately, without actually waiting for an established connection.

There might be a better solution, but this solves the issue in all the environments \ networks I was testing this on.